### PR TITLE
Make sure that appropiate json strings are passed.

### DIFF
--- a/pennylane_ls/MultiQuditOps.py
+++ b/pennylane_ls/MultiQuditOps.py
@@ -65,7 +65,7 @@ class rLx(MultiQuditOperation):
     def qudit_operator(cls, par, wires):
         theta = par[0]
 
-        l_obj = ("rLx", [wires[0]], [theta % (2 * np.pi)])
+        l_obj = ("rlx", [wires[0]], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -82,7 +82,7 @@ class rLz(MultiQuditOperation):
     @classmethod
     def qudit_operator(cls, par, wires):
         theta = par[0]
-        l_obj = ("rLz", [wires[0]], [theta % (2 * np.pi)])
+        l_obj = ("rlz", [wires[0]], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -99,7 +99,7 @@ class rLz2(MultiQuditOperation):
     @classmethod
     def qudit_operator(cls, par, wires):
         theta = par[0]
-        l_obj = ("rLz2", [wires[0]], [theta % (2 * np.pi)])
+        l_obj = ("rlz2", [wires[0]], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -131,7 +131,7 @@ class LxLy(MultiQuditOperation):
     @classmethod
     def qudit_operator(cls, par, wires):
         theta = par[0]
-        l_obj = ("LxLy", [wires[0], wires[1]], [theta % (2 * np.pi)])
+        l_obj = ("rlxly", [wires[0], wires[1]], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -145,7 +145,7 @@ class LzLz(MultiQuditOperation):
     @classmethod
     def qudit_operator(cls, par, wires):
         theta = par[0]
-        l_obj = ("LzLz", [wires[0], wires[1]], [theta % (2 * np.pi)])
+        l_obj = ("rlzlz", [wires[0], wires[1]], [theta % (2 * np.pi)])
         return l_obj, False
 
 

--- a/pennylane_ls/SingleQuditOps.py
+++ b/pennylane_ls/SingleQuditOps.py
@@ -62,7 +62,7 @@ class rLx(SingleQuditOperation):
     def qudit_operator(cls, par):
         theta = par[0]
 
-        l_obj = ("rLx", [0], [theta % (2 * np.pi)])
+        l_obj = ("rlx", [0], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -79,7 +79,7 @@ class rLz(SingleQuditOperation):
     @classmethod
     def qudit_operator(cls, par):
         theta = par[0]
-        l_obj = ("rLz", [0], [theta % (2 * np.pi)])
+        l_obj = ("rlz", [0], [theta % (2 * np.pi)])
         return l_obj, False
 
 
@@ -95,7 +95,7 @@ class rLz2(SingleQuditOperation):
 
     @classmethod
     def qudit_operator(cls, par):
-        l_obj = ("rLz2", [0], par)
+        l_obj = ("rlz2", [0], par)
         return l_obj, False
 
 


### PR DESCRIPTION
The backend now only accepts json strings in lower-cases as this is the appropiate python syntax. This PR should fix the incompatibility that we are observing in the tests of #45.